### PR TITLE
Added setting default encoding for query parser in zend index

### DIFF
--- a/src/Mmanos/Search/Index/Zend.php
+++ b/src/Mmanos/Search/Index/Zend.php
@@ -5,6 +5,21 @@ use Config;
 class Zend extends \Mmanos\Search\Index
 {
 	/**
+	 * Create a new zend instance.
+	 *
+	 * @param string $name
+	 * @param string $driver
+	 * 
+	 * @return void
+	 */
+	public function __construct($name, $driver)
+	{
+		parent::__construct($name, $driver);
+		
+		\ZendSearch\Lucene\Search\QueryParser::setDefaultEncoding('UTF-8');
+	}
+	
+	/**
 	 * Instance of a ZendSearch lucene index.
 	 *
 	 * @var \ZendSearch\Lucene\Index


### PR DESCRIPTION
I think this is the cause of some issues with certain characters in the Zend index.

http://stackoverflow.com/questions/4723135/invalid-characters-for-lucene-text-search
https://github.com/zendframework/ZendSearch/issues/9
