### PR TITLE
Changed elastic search driver to return stored fields with results

### DIFF
--- a/src/Mmanos/Search/Index/Elasticsearch.php
+++ b/src/Mmanos/Search/Index/Elasticsearch.php
@@ -225,6 +225,16 @@ class Elasticsearch extends \Mmanos\Search\Index
 		
 		if (array_get($response, 'hits.hits')) {
 			foreach (array_get($response, 'hits.hits') as $hit) {
+				$fields = array(
+					'id'     => array_get($hit, '_id'),
+					'_score' => array_get($hit, '_score'),
+				);
+				$source = array_get($hit, '_source', array());
+
+				foreach ($source as $name => $value) {
+					$fields[$name] = $value;
+				}
+
 				$parameters = array_get($hit, '_source._parameters');
 				
 				if (!empty($parameters)) {
@@ -234,13 +244,7 @@ class Elasticsearch extends \Mmanos\Search\Index
 					$parameters = array();
 				}
 				
-				$results[] = array_merge(
-					array(
-						'id'     => array_get($hit, '_id'),
-						'_score' => array_get($hit, '_score'),
-					),
-					$parameters
-				);
+				$results[] = array_merge($fields, $parameters);
 			}
 		}
 		


### PR DESCRIPTION
In ElasticSearch, by default fields are stored in the index and returned with hits and now they will be returned with the results and match the latest change to the Zend driver.