### PR TITLE
Added where null method to query to match null values

### DIFF
--- a/src/Mmanos/Search/Index.php
+++ b/src/Mmanos/Search/Index.php
@@ -86,6 +86,19 @@ abstract class Index
 	
 	/**
 	 * Initialize and return a new Query instance on this index
+	 * with the requested where null condition.
+	 *
+	 * @param string $field
+	 * 
+	 * @return \Mmanos\Search\Query
+	 */
+	public function whereNull($field)
+	{
+		return $this->query()->whereNull($field);
+	}
+	
+	/**
+	 * Initialize and return a new Query instance on this index
 	 * with the requested geo distance where clause.
 	 *
 	 * @param float $lat
@@ -154,6 +167,7 @@ abstract class Index
 	 *                         - value      : value to match
 	 *                         - required   : must match
 	 *                         - prohibited : must not match
+	 *                         - missing    : must match null value
 	 *                         - phrase     : match as a phrase
 	 *                         - filter     : filter results on value
 	 *                         - fuzzy      : fuzziness value (0 - 1)

--- a/src/Mmanos/Search/Index/Elasticsearch.php
+++ b/src/Mmanos/Search/Index/Elasticsearch.php
@@ -88,6 +88,7 @@ class Elasticsearch extends \Mmanos\Search\Index
 	 *                         - value      : value to match
 	 *                         - required   : must match
 	 *                         - prohibited : must not match
+	 *                         - missing    : must match null value
 	 *                         - phrase     : match as a phrase
 	 *                         - filter     : filter results on value
 	 *                         - fuzzy      : fuzziness value (0 - 1)
@@ -138,6 +139,15 @@ class Elasticsearch extends \Mmanos\Search\Index
 			);
 
 			$query['body']['query']['filtered']['filter']['geo_distance'] = $definition;
+
+			return $query;
+		}
+		elseif (!empty($condition['missing'])) {
+			$definition = array(
+				'field' => $field[0],
+			);
+
+			$query['body']['query']['filtered']['filter']['missing'] = $definition;
 
 			return $query;
 		}

--- a/src/Mmanos/Search/Query.php
+++ b/src/Mmanos/Search/Query.php
@@ -96,6 +96,24 @@ class Query
 		
 		return $this;
 	}
+
+	/**
+	 * Add a where clause for a field to match null values.
+	 *
+	 * @param string $field
+	 * 
+	 * @return \Mmanos\Search\Query
+	 */
+	public function whereNull($field)
+	{
+		$this->query = $this->index->addConditionToQuery($this->query, array(
+			'field'    => $field,
+			'required' => true,
+			'missing'  => true,
+		));
+		
+		return $this;
+	}
 	
 	/**
 	 * Add a geo distance where clause to the query.


### PR DESCRIPTION
This adds a `whereNull()` method to query class similar to Eloquent has which will match null values across all search drivers since a simple `Search::where('field', null)` will not work with search drivers with complex data type support such arrays.
